### PR TITLE
fix: improve accessibility of auto-approve toggles

### DIFF
--- a/webview-ui/src/components/settings/AutoApproveToggle.tsx
+++ b/webview-ui/src/components/settings/AutoApproveToggle.tsx
@@ -105,6 +105,8 @@ export const AutoApproveToggle = ({ onToggle, ...props }: AutoApproveToggleProps
 					variant={props[key] ? "default" : "outline"}
 					onClick={() => onToggle(key, !props[key])}
 					title={t(descriptionKey || "")}
+					aria-label={t(labelKey)}
+					aria-pressed={props[key]}
 					data-testid={testId}
 					className={cn(" aspect-square h-[80px]", !props[key] && "opacity-50")}>
 					<span className={cn("flex flex-col items-center gap-1")}>

--- a/webview-ui/src/components/settings/__tests__/AutoApproveToggle.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/AutoApproveToggle.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, fireEvent } from "@testing-library/react"
+import "@testing-library/jest-dom"
+
+import { AutoApproveToggle, autoApproveSettingsConfig } from "../AutoApproveToggle"
+import { TranslationProvider } from "@/i18n/__mocks__/TranslationContext"
+
+jest.mock("@/i18n/TranslationContext", () => {
+	const actual = jest.requireActual("@/i18n/TranslationContext")
+	return {
+		...actual,
+		useAppTranslation: () => ({
+			t: (key: string) => key,
+		}),
+	}
+})
+
+describe("AutoApproveToggle", () => {
+	const mockOnToggle = jest.fn()
+	const initialProps = {
+		alwaysAllowReadOnly: true,
+		alwaysAllowWrite: false,
+		alwaysAllowBrowser: false,
+		alwaysApproveResubmit: true,
+		alwaysAllowMcp: false,
+		alwaysAllowModeSwitch: true,
+		alwaysAllowSubtasks: false,
+		alwaysAllowExecute: true,
+		onToggle: mockOnToggle,
+	}
+
+	beforeEach(() => {
+		mockOnToggle.mockClear()
+	})
+
+	test("renders all toggle buttons with correct initial ARIA attributes", () => {
+		render(
+			<TranslationProvider>
+				<AutoApproveToggle {...initialProps} />
+			</TranslationProvider>,
+		)
+
+		Object.values(autoApproveSettingsConfig).forEach((config) => {
+			const button = screen.getByTestId(config.testId)
+			expect(button).toBeInTheDocument()
+			expect(button).toHaveAttribute("aria-label", config.labelKey)
+			expect(button).toHaveAttribute("aria-pressed", String(initialProps[config.key]))
+		})
+	})
+
+	test("calls onToggle with the correct key and value when a button is clicked", () => {
+		render(
+			<TranslationProvider>
+				<AutoApproveToggle {...initialProps} />
+			</TranslationProvider>,
+		)
+
+		const writeToggleButton = screen.getByTestId(autoApproveSettingsConfig.alwaysAllowWrite.testId)
+		fireEvent.click(writeToggleButton)
+
+		expect(mockOnToggle).toHaveBeenCalledTimes(1)
+		expect(mockOnToggle).toHaveBeenCalledWith("alwaysAllowWrite", true)
+
+		const readOnlyButton = screen.getByTestId(autoApproveSettingsConfig.alwaysAllowReadOnly.testId)
+		fireEvent.click(readOnlyButton)
+		expect(mockOnToggle).toHaveBeenCalledTimes(2)
+		expect(mockOnToggle).toHaveBeenCalledWith("alwaysAllowReadOnly", false)
+	})
+
+	test("updates aria-pressed attribute after toggle", () => {
+		const { rerender } = render(
+			<TranslationProvider>
+				<AutoApproveToggle {...initialProps} />
+			</TranslationProvider>,
+		)
+
+		const writeToggleButton = screen.getByTestId(autoApproveSettingsConfig.alwaysAllowWrite.testId)
+		expect(writeToggleButton).toHaveAttribute("aria-pressed", "false")
+
+		const updatedProps = { ...initialProps, alwaysAllowWrite: true }
+		rerender(
+			<TranslationProvider>
+				<AutoApproveToggle {...updatedProps} />
+			</TranslationProvider>,
+		)
+
+		expect(screen.getByTestId(autoApproveSettingsConfig.alwaysAllowWrite.testId)).toHaveAttribute(
+			"aria-pressed",
+			"true",
+		)
+	})
+})


### PR DESCRIPTION
# Improve Accessibility of Auto-Approve Toggles

**Issue:** The auto-approve toggle buttons in the settings view were not fully accessible to screen reader users. While visually distinct, they lacked the necessary ARIA attributes to convey their purpose and state programmatically.

**Solution:** This PR addresses the accessibility issues by making the following changes to the `AutoApproveToggle` component (`webview-ui/src/components/settings/AutoApproveToggle.tsx`):

1.  **Added `aria-label`:** Each toggle button now has an `aria-label` attribute derived from its corresponding setting label (e.g., "Read Only Files", "Write Files"). This clearly communicates the *purpose* of each button to screen readers.
2.  **Added `aria-pressed`:** Each toggle button now includes an `aria-pressed` attribute. This attribute is dynamically set to `true` or `false` based on the current state of the setting, explicitly informing screen reader users whether the toggle is currently enabled or disabled.

**Testing:**

*   A new test suite (`webview-ui/src/components/settings/__tests__/AutoApproveToggle.test.tsx`) was created specifically for the `AutoApproveToggle` component.
*   Tests were added to verify that:
    *   All toggle buttons render correctly.
    *   The `onToggle` callback functions as expected.
    *   The correct `aria-label` is applied to each button.
    *   The `aria-pressed` attribute accurately reflects the button's state (true/false).
*   All tests pass successfully.

**Impact:** These changes significantly improve the accessibility of the auto-approve settings, allowing screen reader users to understand and interact with these toggles effectively.